### PR TITLE
Add TAP output to test.tap for CI consumption

### DIFF
--- a/lib/lib.rb
+++ b/lib/lib.rb
@@ -69,6 +69,7 @@ def logger
       OutputLogger.new(),
       OutputLogger.new("#{log_location}/#{time_prefix}test.log", false),
       OutputLogger.new("#{log_location}/#{time_prefix}test.color.log", true),
+      TapLogger.new("#{log_location}/#{time_prefix}test.tap"),
       LogCropper.new(hammer_log_file, "#{log_location}/#{time_prefix}hammer.fail.log", true),
       LogCropper.new(hammer_log_file, "#{log_location}/#{time_prefix}hammer.log"),
       LogCropper.new(foreman_log_file, "#{log_location}/#{time_prefix}foreman.fail.log", true),

--- a/lib/loggers.rb
+++ b/lib/loggers.rb
@@ -223,3 +223,39 @@ class LogCropper < FileLogger
   end
 
 end
+
+
+class TapLogger < FileLogger
+
+  def initialize(target_file=nil)
+    @target_file = target_file
+    @counter = 0
+    @buffer = []
+    clear_target
+  end
+
+  def log_command(command, command_no, result, section_chain)
+    desc = "#{command} [command #{command_no}]"
+    desc += "\n" + result.stderr.rstrip unless result.ok?
+    log_tap(result.ok?, desc, section_chain)
+  end
+
+  def log_test(status, desc, section_chain)
+    log_tap(status, desc, section_chain)
+  end
+
+  def log_statistics(stat_lists)
+    puts "1..#{@counter}"
+    @buffer.each { |b| puts b }
+  end
+
+  protected
+
+  def log_tap(status, desc, section_chain)
+    @counter += 1
+    @buffer << "#{status ? 'ok' : 'not ok'} #{@counter} #{(section_chain.clone << desc.split("\n").first).join(' | ')}"
+    cont = desc.split("\n")[1..-1].map { |d| '  ' + d }
+    @buffer << cont.join("\n") unless cont.empty?
+  end
+
+end


### PR DESCRIPTION
Jenkins is configured to read [TAP](https://en.wikipedia.org/wiki/Test_Anything_Protocol) files, so we can present more detailed information about test failures in the UI for the [hammer tests](http://ci.theforeman.org/job/systest_foreman_hammer_nightly/).

Example generated output: http://paste.fedoraproject.org/137712/20733441/raw/
Example job view (click the test result links): http://ci.theforeman.org/job/tapstest/5/
