### PR TITLE
Fixing broken tests

### DIFF
--- a/tests/001_base.rb
+++ b/tests/001_base.rb
@@ -4,7 +4,7 @@ def test_os_association(resource, params)
   section "add/remove os" do
     simple_test resource, "add-operatingsystem", "--operatingsystem", @os_label, params
 
-    test "os associated" do
+    section "os associated" do
       res = hammer resource, "info", params
       out = ShowOutput.new(res.stdout)
 

--- a/tests/004_roles.rb
+++ b/tests/004_roles.rb
@@ -29,11 +29,11 @@ section "filter" do
 
   section "available permissions and resources" do
 
-    test "permissions" do
+    section "permissions" do
       simple_test "filter", "available-permissions"
     end
 
-    test "resources" do
+    section "resources" do
       simple_test "filter", "available-resources"
     end
 


### PR DESCRIPTION
During last refactoring the test started to test
the return value of the block and it is not safe
to use it instead of section anymore.